### PR TITLE
Add autoscaling to github runners

### DIFF
--- a/org_runners.tf
+++ b/org_runners.tf
@@ -11,7 +11,6 @@ resource "kubernetes_manifest" "github_org_runners" {
     }
 
     spec = {
-      replicas = each.value.replicas
       template = {
         spec = {
           organization       = each.value.name
@@ -27,6 +26,37 @@ resource "kubernetes_manifest" "github_org_runners" {
           affinity    = each.value.affinity
         }
       }
+    }
+  }
+}
+
+resource "kubernetes_manifest" "github_org_runners_horizontal_autoscaler" {
+  for_each = { for org in var.github_org_runners : org.name => org }
+
+  manifest = {
+    apiVersion = "actions.summerwind.dev/v1alpha1"
+    kind       = "HorizontalRunnerAutoscaler"
+
+    metadata = {
+      name      = "${lower(each.value.name)}-runner-deployment"
+      namespace = helm_release.release.namespace
+    }
+
+    spec = {
+      minReplicas = each.value.min_replicas
+      maxReplicas = each.value.max_replicas
+      scaleTargetRef = {
+        kind = "RunnerDeployment"
+        name = "${lower(each.value.name)}-runner-deployment"
+      }
+      scaleUpTriggers = [
+        {
+          githubEvent = {
+            workflowJob = {}
+          }
+          duration = each.value.scale_up_trigger_duration
+        },
+      ]
     }
   }
 }


### PR DESCRIPTION
[PFMENG-455] 
BREAKING CHANGE:
- replicas removed, added the need for min_replicas and max_replicas
https://github.com/actions-runner-controller/actions-runner-controller/blob/master/docs/detailed-docs.md#webhook-driven-scaling

[PFMENG-455]: https://sph.atlassian.net/browse/PFMENG-455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ