### PR TITLE
[PFMENG-5726] Fix: Add Karpenter do-not-disrupt annotation to ARC runner scale set pods

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,8 +39,9 @@ module "action_runner_scale_set" {
   topology_spread_constraints = var.runner_topology_spread_constraints
   affinity                    = var.runner_affinity
 
-  template_spec_config_type     = var.runner_template_spec_config_type
-  template_spec_metadata_labels = var.runner_template_spec_metadata_labels
+  template_spec_config_type          = var.runner_template_spec_config_type
+  template_spec_metadata_labels      = var.runner_template_spec_metadata_labels
+  template_spec_metadata_annotations = var.runner_template_spec_metadata_annotations
 
   container_mode_type = var.runner_container_mode_type
   runner_resources    = var.runner_resources

--- a/modules/gha-runner-scale-set/main.tf
+++ b/modules/gha-runner-scale-set/main.tf
@@ -30,11 +30,15 @@ locals {
     github_app_private_key     = var.github_app_private_key
     github_token               = var.github_token
 
-    container_mode_type        = var.container_mode_type
-    listener_template_spec     = yamlencode(local.listener_template_spec)
-    template_spec_config_type  = var.template_spec_config_type
-    template_spec              = yamlencode(local.template_spec)
-    controller_service_account = yamlencode(var.controller_service_account)
+    container_mode_type                    = var.container_mode_type
+    listener_template_spec                 = yamlencode(local.listener_template_spec)
+    template_spec_config_type              = var.template_spec_config_type
+    template_spec                          = yamlencode(local.template_spec)
+    controller_service_account             = yamlencode(var.controller_service_account)
+    template_spec_metadata_labels          = yamlencode(var.template_spec_metadata_labels)
+    template_spec_metadata_annotations     = yamlencode(var.template_spec_metadata_annotations)
+    has_template_spec_metadata_labels      = length(var.template_spec_metadata_labels) > 0
+    has_template_spec_metadata_annotations = length(var.template_spec_metadata_annotations) > 0
   }
 
   listener_template_spec = {
@@ -61,7 +65,8 @@ locals {
 
   template_spec = {
     metadata = {
-      labels = var.template_spec_metadata_labels
+      labels      = var.template_spec_metadata_labels
+      annotations = var.template_spec_metadata_annotations
     }
     spec = {
       topologySpreadConstraints = var.topology_spread_constraints

--- a/modules/gha-runner-scale-set/main.tf
+++ b/modules/gha-runner-scale-set/main.tf
@@ -39,6 +39,7 @@ locals {
     template_spec_metadata_annotations     = yamlencode(var.template_spec_metadata_annotations)
     has_template_spec_metadata_labels      = length(var.template_spec_metadata_labels) > 0
     has_template_spec_metadata_annotations = length(var.template_spec_metadata_annotations) > 0
+    runner_resources                       = yamlencode(var.runner_resources)
   }
 
   listener_template_spec = {

--- a/modules/gha-runner-scale-set/templates/values.yaml
+++ b/modules/gha-runner-scale-set/templates/values.yaml
@@ -108,83 +108,19 @@ listenerTemplate:
 %{ if container_mode_type == "" }
 template:
   ${indent(2,template_spec)}
-  ## template.spec will be modified if you change the container mode
-  ## with containerMode.type=dind, we will populate the template.spec with following pod spec
-  ##   spec:
-  ##     initContainers:
-  ##     - name: init-dind-externals
-  ##       image: ghcr.io/actions/actions-runner:latest
-  ##       command: ["cp", "-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
-  ##       volumeMounts:
-  ##         - name: dind-externals
-  ##           mountPath: /home/runner/tmpDir
-  ##     containers:
-  ##     - name: runner
-  ##       image: ghcr.io/actions/actions-runner:latest
-  ##       command: ["/home/runner/run.sh"]
-  ##       env:
-  ##         - name: DOCKER_HOST
-  ##           value: unix:///run/docker/docker.sock
-  ##       volumeMounts:
-  ##         - name: work
-  ##           mountPath: /home/runner/_work
-  ##         - name: dind-sock
-  ##           mountPath: /run/docker
-  ##           readOnly: true
-  ##     - name: dind
-  ##       image: docker:dind
-  ##       args:
-  ##         - dockerd
-  ##         - --host=unix:///run/docker/docker.sock
-  ##         - --group=$(DOCKER_GROUP_GID)
-  ##       env:
-  ##         - name: DOCKER_GROUP_GID
-  ##           value: "123"
-  ##       securityContext:
-  ##         privileged: true
-  ##       volumeMounts:
-  ##         - name: work
-  ##           mountPath: /home/runner/_work
-  ##         - name: dind-sock
-  ##           mountPath: /run/docker
-  ##         - name: dind-externals
-  ##           mountPath: /home/runner/externals
-  ##     volumes:
-  ##     - name: work
-  ##       emptyDir: {}
-  ##     - name: dind-sock
-  ##       emptyDir: {}
-  ##     - name: dind-externals
-  ##       emptyDir: {}
-  ######################################################################################################
-  ## with containerMode.type=kubernetes, we will populate the template.spec with following pod spec
-  ## template:
-  ##   spec:
-  ##     containers:
-  ##     - name: runner
-  ##       image: ghcr.io/actions/actions-runner:latest
-  ##       env:
-  ##         - name: ACTIONS_RUNNER_CONTAINER_HOOKS
-  ##           value: /home/runner/k8s/index.js
-  ##         - name: ACTIONS_RUNNER_POD_NAME
-  ##           valueFrom:
-  ##             fieldRef:
-  ##               fieldPath: metadata.name
-  ##         - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
-  ##           value: "true"
-  ##       volumeMounts:
-  ##         - name: work
-  ##           mountPath: /home/runner/_work
-  ##     volumes:
-  ##       - name: work
-  ##         ephemeral:
-  ##           volumeClaimTemplate:
-  ##             spec:
-  ##               accessModes: [ "ReadWriteOnce" ]
-  ##               storageClassName: "local-path"
-  ##               resources:
-  ##                 requests:
-  ##                   storage: 1Gi
+%{ else }
+%{ if has_template_spec_metadata_annotations || has_template_spec_metadata_labels }
+template:
+  metadata:
+%{ if has_template_spec_metadata_annotations }
+    annotations:
+      ${indent(6, template_spec_metadata_annotations)}
+%{ endif }
+%{ if has_template_spec_metadata_labels }
+    labels:
+      ${indent(6, template_spec_metadata_labels)}
+%{ endif }
+%{ endif }
 %{ endif }
 ## Optional controller service account that needs to have required Role and RoleBinding
 ## to operate this gha-runner-scale-set installation.

--- a/modules/gha-runner-scale-set/templates/values.yaml
+++ b/modules/gha-runner-scale-set/templates/values.yaml
@@ -109,8 +109,8 @@ listenerTemplate:
 template:
   ${indent(2,template_spec)}
 %{ else }
-%{ if has_template_spec_metadata_annotations || has_template_spec_metadata_labels }
 template:
+%{ if has_template_spec_metadata_annotations || has_template_spec_metadata_labels }
   metadata:
 %{ if has_template_spec_metadata_annotations }
     annotations:
@@ -121,6 +121,11 @@ template:
       ${indent(6, template_spec_metadata_labels)}
 %{ endif }
 %{ endif }
+  spec:
+    containers:
+    - name: runner
+      resources:
+        ${indent(8, runner_resources)}
 %{ endif }
 ## Optional controller service account that needs to have required Role and RoleBinding
 ## to operate this gha-runner-scale-set installation.

--- a/modules/gha-runner-scale-set/variables.tf
+++ b/modules/gha-runner-scale-set/variables.tf
@@ -130,6 +130,14 @@ variable "template_spec_metadata_labels" {
   default     = {}
 }
 
+variable "template_spec_metadata_annotations" {
+  description = "Annotations to be added to the pod template metadata."
+  type        = map(string)
+  default = {
+    "karpenter.sh/do-not-disrupt" = "true"
+  }
+}
+
 variable "controller_service_account" {
   description = "Service account for the controller."
   type        = map(any)

--- a/variables.tf
+++ b/variables.tf
@@ -145,6 +145,14 @@ variable "runner_template_spec_metadata_labels" {
   default     = {}
 }
 
+variable "runner_template_spec_metadata_annotations" {
+  description = "Annotations to be added to the pod template metadata."
+  type        = map(string)
+  default = {
+    "karpenter.sh/do-not-disrupt" = "true"
+  }
+}
+
 variable "runner_node_selector" {
   description = "Node selector for the runner pods"
   type        = any


### PR DESCRIPTION
### Description
This PR adds support for custom pod template annotations in the Action Runner Controller (ARC) Helm module, and defaults `runner_template_spec_metadata_annotations` to include `"karpenter.sh/do-not-disrupt" = "true"` to prevent Karpenter from evicting runners mid-job.

### Links
- **Jira Story:** [PFMENG-5726](https://sph.atlassian.net/browse/PFMENG-5726)

[PFMENG-5726]: https://sph.atlassian.net/browse/PFMENG-5726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ