### PR TITLE
[PFMENG-5728] Fix: Separate template_spec_dind to exclude duplicate volumes and initContainers

### DIFF
--- a/modules/gha-runner-scale-set/main.tf
+++ b/modules/gha-runner-scale-set/main.tf
@@ -34,6 +34,7 @@ locals {
     listener_template_spec                 = yamlencode(local.listener_template_spec)
     template_spec_config_type              = var.template_spec_config_type
     template_spec                          = yamlencode(local.template_spec)
+    template_spec_dind                     = yamlencode(local.template_spec_dind)
     controller_service_account             = yamlencode(var.controller_service_account)
     template_spec_metadata_labels          = yamlencode(var.template_spec_metadata_labels)
     template_spec_metadata_annotations     = yamlencode(var.template_spec_metadata_annotations)
@@ -182,6 +183,62 @@ locals {
           name     = "dind-externals"
           emptyDir = {}
         },
+      ]
+    }
+  }
+
+  template_spec_dind = {
+    metadata = {
+      labels      = var.template_spec_metadata_labels
+      annotations = var.template_spec_metadata_annotations
+    }
+    spec = {
+      topologySpreadConstraints = var.topology_spread_constraints
+      nodeSelector              = var.node_selector
+      tolerations               = var.tolerations
+      affinity                  = var.affinity
+
+      containers = [
+        {
+          name    = "runner"
+          image   = "ghcr.io/actions/actions-runner:latest"
+          command = ["/home/runner/run.sh"]
+          env = [
+            {
+              name  = "DOCKER_HOST"
+              value = "unix:///var/run/docker.sock"
+            },
+            {
+              name  = "RUNNER_WAIT_FOR_DOCKER_IN_SECONDS"
+              value = "120"
+            },
+            {
+              name  = "NPM_CONFIG_IGNORE_SCRIPTS",
+              value = "1"
+            },
+          ]
+          volumeMounts = [
+            {
+              name      = "work"
+              mountPath = "/home/runner/_work"
+            },
+            {
+              name      = "dind-sock"
+              mountPath = "/var/run"
+              readOnly  = true
+            },
+          ]
+          resources = {
+            requests = {
+              cpu    = var.runner_resources.requests.cpu
+              memory = var.runner_resources.requests.memory
+            }
+            limits = {
+              cpu    = var.runner_resources.limits.cpu
+              memory = var.runner_resources.limits.memory
+            }
+          }
+        }
       ]
     }
   }

--- a/modules/gha-runner-scale-set/templates/values.yaml
+++ b/modules/gha-runner-scale-set/templates/values.yaml
@@ -105,9 +105,12 @@ listenerTemplate:
 #       image: example-sidecar
 
 ## template is the PodSpec for each runner Pod
-%{ if container_mode_type == "" || container_mode_type == "dind" }
+%{ if container_mode_type == "" }
 template:
   ${indent(2,template_spec)}
+%{ else if container_mode_type == "dind" }
+template:
+  ${indent(2,template_spec_dind)}
 %{ else }
 template:
 %{ if has_template_spec_metadata_annotations || has_template_spec_metadata_labels }


### PR DESCRIPTION
Direct link to Jira Story: https://sph.atlassian.net/browse/PFMENG-5728

This PR fixes the duplicate volumes and initContainers validation error in DinD mode. We resolve this by separating the template spec into template_spec_dind which excludes initContainers and volumes, as they are already automatically injected by the Helm chart templates when containerMode.type is dind.